### PR TITLE
Allow to choose which expander to use in autoscaler profile

### DIFF
--- a/r-aks.tf
+++ b/r-aks.tf
@@ -38,23 +38,23 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dynamic "auto_scaler_profile" {
     for_each = var.auto_scaler_profile != null ? [true] : []
     content {
-      balance_similar_node_groups = auto_scaler_profile.value.balance_similar_node_groups
-      expander = auto_scaler_profile.value.expander
-      max_graceful_termination_sec = auto_scaler_profile.value.max_graceful_termination_sec
-      max_node_provisioning_time = auto_scaler_profile.value.max_node_provisioning_time
-      max_unready_nodes = auto_scaler_profile.value.max_unready_nodes
-      max_unready_percentage = auto_scaler_profile.value.max_unready_percentage
-      new_pod_scale_up_delay = auto_scaler_profile.value.new_pod_scale_up_delay
-      scale_down_delay_after_add = auto_scaler_profile.value.scale_down_delay_after_add
-      scale_down_delay_after_delete = auto_scaler_profile.value.scale_down_delay_after_delete
-      scale_down_delay_after_failure = auto_scaler_profile.value.scale_down_delay_after_failure
-      scan_interval = auto_scaler_profile.value.scan_interval
-      scale_down_unneeded = auto_scaler_profile.value.scale_down_unneeded
-      scale_down_unready = auto_scaler_profile.value.scale_down_unready
+      balance_similar_node_groups      = auto_scaler_profile.value.balance_similar_node_groups
+      expander                         = auto_scaler_profile.value.expander
+      max_graceful_termination_sec     = auto_scaler_profile.value.max_graceful_termination_sec
+      max_node_provisioning_time       = auto_scaler_profile.value.max_node_provisioning_time
+      max_unready_nodes                = auto_scaler_profile.value.max_unready_nodes
+      max_unready_percentage           = auto_scaler_profile.value.max_unready_percentage
+      new_pod_scale_up_delay           = auto_scaler_profile.value.new_pod_scale_up_delay
+      scale_down_delay_after_add       = auto_scaler_profile.value.scale_down_delay_after_add
+      scale_down_delay_after_delete    = auto_scaler_profile.value.scale_down_delay_after_delete
+      scale_down_delay_after_failure   = auto_scaler_profile.value.scale_down_delay_after_failure
+      scan_interval                    = auto_scaler_profile.value.scan_interval
+      scale_down_unneeded              = auto_scaler_profile.value.scale_down_unneeded
+      scale_down_unready               = auto_scaler_profile.value.scale_down_unready
       scale_down_utilization_threshold = auto_scaler_profile.value.scale_down_utilization_threshold
-      empty_bulk_delete_max = auto_scaler_profile.value.empty_bulk_delete_max
-      skip_nodes_with_local_storage = auto_scaler_profile.value.skip_nodes_with_local_storage
-      skip_nodes_with_system_pods = auto_scaler_profile.value.skip_nodes_with_system_pods
+      empty_bulk_delete_max            = auto_scaler_profile.value.empty_bulk_delete_max
+      skip_nodes_with_local_storage    = auto_scaler_profile.value.skip_nodes_with_local_storage
+      skip_nodes_with_system_pods      = auto_scaler_profile.value.skip_nodes_with_system_pods
     }
   }
 

--- a/r-aks.tf
+++ b/r-aks.tf
@@ -36,8 +36,25 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   dynamic "auto_scaler_profile" {
-    for_each = var.auto_scaler_expander_name != null ? [true] : []
+    for_each = var.auto_scaler_profile != null ? [true] : []
     content {
+      balance_similar_node_groups = auto_scaler_profile.value.balance_similar_node_groups
+      expander = auto_scaler_profile.value.expander
+      max_graceful_termination_sec = auto_scaler_profile.value.max_graceful_termination_sec
+      max_node_provisioning_time = auto_scaler_profile.value.max_node_provisioning_time
+      max_unready_nodes = auto_scaler_profile.value.max_unready_nodes
+      max_unready_percentage = auto_scaler_profile.value.max_unready_percentage
+      new_pod_scale_up_delay = auto_scaler_profile.value.new_pod_scale_up_delay
+      scale_down_delay_after_add = auto_scaler_profile.value.scale_down_delay_after_add
+      scale_down_delay_after_delete = auto_scaler_profile.value.scale_down_delay_after_delete
+      scale_down_delay_after_failure = auto_scaler_profile.value.scale_down_delay_after_failure
+      scan_interval = auto_scaler_profile.value.scan_interval
+      scale_down_unneeded = auto_scaler_profile.value.scale_down_unneeded
+      scale_down_unready = auto_scaler_profile.value.scale_down_unready
+      scale_down_utilization_threshold = auto_scaler_profile.value.scale_down_utilization_threshold
+      empty_bulk_delete_max = auto_scaler_profile.value.empty_bulk_delete_max
+      skip_nodes_with_local_storage = auto_scaler_profile.value.skip_nodes_with_local_storage
+      skip_nodes_with_system_pods = auto_scaler_profile.value.skip_nodes_with_system_pods
       expander = var.auto_scaler_expander_name
     }
   }

--- a/r-aks.tf
+++ b/r-aks.tf
@@ -55,7 +55,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
       empty_bulk_delete_max = auto_scaler_profile.value.empty_bulk_delete_max
       skip_nodes_with_local_storage = auto_scaler_profile.value.skip_nodes_with_local_storage
       skip_nodes_with_system_pods = auto_scaler_profile.value.skip_nodes_with_system_pods
-      expander = var.auto_scaler_expander_name
     }
   }
 

--- a/r-aks.tf
+++ b/r-aks.tf
@@ -35,6 +35,13 @@ resource "azurerm_kubernetes_cluster" "aks" {
     identity_ids = [azurerm_user_assigned_identity.aks_user_assigned_identity.id]
   }
 
+  dynamic "auto_scaler_profile" {
+    for_each = var.auto_scaler_expander_name
+    content {
+      expander = auto_scaler_expander_name.value
+    }
+  }
+
   oms_agent {
     log_analytics_workspace_id = var.oms_log_analytics_workspace_id
   }

--- a/r-aks.tf
+++ b/r-aks.tf
@@ -36,9 +36,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   dynamic "auto_scaler_profile" {
-    for_each = var.auto_scaler_expander_name
+    for_each = var.auto_scaler_expander_name != null ? [true] : []
     content {
-      expander = auto_scaler_expander_name.value
+      expander = var.auto_scaler_expander_name
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -175,6 +175,12 @@ variable "nodes_subnet_id" {
   type        = string
 }
 
+variable "auto_scaler_expander_name" {
+  description = "Cluster autoscaler Expander to use. Possible values are least-waste, priority, most-pods and random. Defaults to random. See more details on https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander"
+  type        = string
+  default     = null
+}
+
 variable "oms_log_analytics_workspace_id" {
   description = "The ID of the Log Analytics Workspace used to send OMS logs"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -198,6 +198,7 @@ variable "auto_scaler_profile" {
   }))
   default = null
 }
+
 variable "oms_log_analytics_workspace_id" {
   description = "The ID of the Log Analytics Workspace used to send OMS logs"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -175,12 +175,29 @@ variable "nodes_subnet_id" {
   type        = string
 }
 
-variable "auto_scaler_expander_name" {
-  description = "Cluster autoscaler Expander to use. Possible values are least-waste, priority, most-pods and random. Defaults to random. See more details on https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander"
-  type        = string
-  default     = null
+variable "auto_scaler_profile" {
+  description = "Map to configure `auto_scaler_profile` block."
+  type = map(object({
+    balance_similar_node_groups      = optional(bool, false)
+    expander                         = optional(string, "random")
+    max_graceful_termination_sec     = optional(number, 600)
+    max_node_provisioning_time       = optional(string, "15m")
+    max_unready_nodes                = optional(number, 3)
+    max_unready_percentage           = optional(number, 45)
+    new_pod_scale_up_delay           = optional(string, "10s")
+    scale_down_delay_after_add       = optional(string, "10m")
+    scale_down_delay_after_delete    = optional(string, "10s")
+    scale_down_delay_after_failure   = optional(string, "3m")
+    scan_interval                    = optional(string, "10s")
+    scale_down_unneeded              = optional(string, "10m")
+    scale_down_unready               = optional(string, "20m")
+    scale_down_utilization_threshold = optional(number, 0.5)
+    empty_bulk_delete_max            = optional(number, 10)
+    skip_nodes_with_local_storage    = optional(bool, true)
+    skip_nodes_with_system_pods      = optional(bool, true)
+  }))
+  default = null
 }
-
 variable "oms_log_analytics_workspace_id" {
   description = "The ID of the Log Analytics Workspace used to send OMS logs"
   type        = string


### PR DESCRIPTION
Cluster autoscaler scales nodes in pool depending upon their load
But if there’s not the only one node pool, it scales randomly by default
This patch enables cluster autoscaler's `expander` parameter which allows to use non-random types, e.g. `priority` which can scale nodes in pools according to the configmap like [this](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/priority-expander-configmap.yaml)