### PR TITLE
Fix node_count error when autoscaler is enabled

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   default_agent_profile = {
     name                   = var.default_node_pool.name
-    node_count             = var.default_node_pool.enable_auto_scaling == true ? var.default_node_pool.min_count : var.default_node_pool.node_count
+    node_count             = var.default_node_pool.node_count
     vm_size                = var.default_node_pool.vm_size
     os_type                = var.default_node_pool.os_type
     zones                  = var.default_node_pool.zones

--- a/r-aks.tf
+++ b/r-aks.tf
@@ -23,7 +23,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   default_node_pool {
     name                = local.default_node_pool.name
-    node_count          = local.default_node_pool.node_count
+    node_count          = local.default_node_pool.enable_auto_scaling == true ? null : local.default_node_pool.node_count
     vm_size             = local.default_node_pool.vm_size
     zones               = local.default_node_pool.zones
     enable_auto_scaling = local.default_node_pool.enable_auto_scaling


### PR DESCRIPTION
There's an error when Auto scaling is enabled:
`Error: expanding "default_node_pool": cannot change "node_count" when "enable_auto_scaling" is set to "true"`
It's caused by this line in the `locals.tf`:
`default_node_pool = merge(local.default_agent_profile, var.default_node_pool)`
As `merge` is used, it rewrites `node_count` to the default value if not set, which causes this error
This PR fixes that